### PR TITLE
Fix signature lookup enable logic

### DIFF
--- a/src/lib/hooks/useSignatureLookup.ts
+++ b/src/lib/hooks/useSignatureLookup.ts
@@ -54,8 +54,13 @@ export const useSignatureLookup = (
 	params: LookupParams,
 	options?: Omit<QueryOptions<ApiResponse, Error>, "queryKey" | "queryFn">,
 ) => {
-	const shouldLookup =
-		!!params.functionHashes?.length && params.functionHashes[0].length === 10;
+       const hasFunctionSelector =
+               !!params.functionHashes?.length &&
+               params.functionHashes[0].length === 10;
+       const hasEventTopic =
+               !!params.eventHashes?.length &&
+               params.eventHashes[0].length === 66;
+       const shouldLookup = hasFunctionSelector || hasEventTopic;
 	return useQuery({
 		queryKey: ["signature-lookup", params],
 		queryFn: () => lookupSignatures(params),


### PR DESCRIPTION
## Summary
- fix enabling event signature lookup when only event hashes are passed

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe2325a20832bb58879b863310a1b