### PR TITLE
Add fullAbi.fromAbi helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ pnpm test
 
 This project uses [Tailwind CSS](https://tailwindcss.com/) for styling.
 
+## ABI Utilities
+
+The `fullAbi` module contains helpers for working with Solidity ABIs. The new
+`fromAbi` function can extract an ABI item from an ABI array by name or by a
+4-byte selector.
+
+```ts
+import { fullAbi } from "@/lib/full-abi"
+
+const item = fullAbi.fromAbi(erc20Abi, "transfer")
+const bySelector = fullAbi.fromAbi(erc20Abi, "0xa9059cbb")
+```
+
 
 ## Linting & Formatting
 

--- a/src/components/Decoder.tsx
+++ b/src/components/Decoder.tsx
@@ -1,7 +1,7 @@
 import { fullAbi } from "@/lib/full-abi";
 import { useSignatureLookup } from "@/lib/hooks/useSignatureLookup";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AbiFunction, type AbiItem } from "ox";
+import type { AbiItem } from "ox";
 import type { Parameter } from "ox/AbiParameters";
 import { useMemo, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
@@ -55,47 +55,38 @@ export default function Decoder() {
 		| Extract<Parameter, { components: readonly Parameter[] }>
 		| null;
 
-	const abiObj = useMemo<
-		| ReturnType<typeof AbiItem.from>
-		| Extract<Parameter, { components: readonly Parameter[] }>
-		| null
-	>(() => {
-		setSigError(null);
-		if (!effectiveSig) return null;
-		try {
-			const parsed = JSON.parse(effectiveSig);
-			if (Array.isArray(parsed)) {
-				// If user provided a selector, try to find by selector, else by name
-				if (selector) {
-					// Find function by selector
-					const fn = AbiFunction.fromAbi(parsed, selector);
-					if (fn) return fn;
-				}
-				// Otherwise, use the first function
-				const fn = AbiFunction.fromAbi(
-					parsed,
-					parsed.find((x) => x.type === "function")?.name || "",
-				);
-				if (fn) return fn;
-				setSigError("No function found in ABI array");
-				return null;
-			}
-			if (typeof parsed === "object" && parsed !== null) {
-				if (parsed.type === "function") return AbiFunction.from(parsed);
-				setSigError("ABI object must be function");
-				return null;
-			}
-		} catch (e) {
-			// Not JSON, fallback to string parsing
-		}
+       const abiObj = useMemo<
+               | ReturnType<typeof AbiItem.from>
+               | Extract<Parameter, { components: readonly Parameter[] }>
+               | null
+       >(() => {
+               setSigError(null);
+               if (!effectiveSig) return null;
+               try {
+                       const parsed = JSON.parse(effectiveSig);
+                       if (Array.isArray(parsed)) {
+                               const item = fullAbi.fromAbi(parsed, selector || undefined);
+                               if (item) return item;
+                               setSigError("No matching item in ABI array");
+                               return null;
+                       }
+                       if (typeof parsed === "object" && parsed !== null) {
+                               const item = fullAbi.fromAbi(parsed as Record<string, unknown>);
+                               if (item) return item;
+                               setSigError("Invalid ABI object");
+                               return null;
+                       }
+               } catch {
+                       // not JSON
+               }
 
-		try {
-			return fullAbi.from(effectiveSig);
-		} catch (e) {
-			setSigError(e instanceof Error ? e.message : "Invalid signature");
-			return null;
-		}
-	}, [effectiveSig, selector]);
+               try {
+                       return fullAbi.from(effectiveSig);
+               } catch (e) {
+                       setSigError(e instanceof Error ? e.message : "Invalid signature");
+                       return null;
+               }
+       }, [effectiveSig, selector]);
 
 	// Type guards
 	function isAbiFunction(obj: AbiObj) {

--- a/src/components/Encoder.tsx
+++ b/src/components/Encoder.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Check, Copy } from "lucide-react";
 import type { AbiItem } from "ox";
 import type { Parameter } from "ox/AbiParameters";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "./ui/button";
@@ -25,25 +25,57 @@ export default function Encoder() {
 
 	const [encoded, setEncoded] = useState<string | null>(null);
 	const [usePacked, setUsePacked] = useState(false);
-	const [copied, setCopied] = useState(false);
-	const copyTimeout = useRef<NodeJS.Timeout | null>(null);
+       const [copied, setCopied] = useState(false);
+       const copyTimeout = useRef<NodeJS.Timeout | null>(null);
+       const [abiItems, setAbiItems] = useState<AbiItem[] | null>(null);
+       const [selectedIndex, setSelectedIndex] = useState(0);
 
-	// Parse function signature with ox
-	const abiObj = useMemo<
-		| ReturnType<typeof AbiItem.from>
-		| Extract<Parameter, { components: readonly Parameter[] }>
-		| null
-	>(() => {
-		setSigError(null);
-		setEncoded(null);
-		if (!sig) return null;
-		try {
-			return fullAbi.from(sig);
-		} catch (e) {
-			setSigError(e instanceof Error ? e.message : "Invalid signature");
-			return null;
-		}
-	}, [sig]);
+       // Parse signature or ABI JSON whenever input changes
+       useEffect(() => {
+               setSigError(null);
+               setEncoded(null);
+               setSelectedIndex(0);
+               try {
+                       const parsed = JSON.parse(sig);
+                       if (Array.isArray(parsed)) {
+                               setAbiItems(parsed as AbiItem[]);
+                               return;
+                       }
+                       if (typeof parsed === "object" && parsed !== null) {
+                               setAbiItems([parsed as AbiItem]);
+                               return;
+                       }
+               } catch {
+                       // ignore JSON parse errors
+               }
+               setAbiItems(null);
+       }, [sig]);
+
+       // Derive ABI item from signature or ABI JSON
+       const abiObj = useMemo<
+               | ReturnType<typeof AbiItem.from>
+               | Extract<Parameter, { components: readonly Parameter[] }>
+               | null
+       >(() => {
+               if (abiItems) {
+                       if (!abiItems.length) return null;
+                       const item = abiItems[Math.min(selectedIndex, abiItems.length - 1)];
+                       try {
+                               return fullAbi.fromAbi(item);
+                       } catch (e) {
+                               setSigError(e instanceof Error ? e.message : "Invalid ABI item");
+                               return null;
+                       }
+               }
+
+               if (!sig) return null;
+               try {
+                       return fullAbi.from(sig);
+               } catch (e) {
+                       setSigError(e instanceof Error ? e.message : "Invalid signature");
+                       return null;
+               }
+       }, [abiItems, selectedIndex, sig]);
 
 	// Step 2: Dynamic param form
 	const paramFields = useMemo(() => {
@@ -87,11 +119,11 @@ export default function Encoder() {
 	return (
 		<div className="bg-gray-50 p-6 rounded-lg border-2 border-dashed max-w-lg border-black shadow flex flex-col gap-6">
 			<h2 className="text-lg font-bold mb-2">EVM Function Encoder</h2>
-			<Form {...sigForm}>
-				<form
-					className="flex flex-col gap-4"
-					onSubmit={sigForm.handleSubmit(() => {})}
-				>
+                        <Form {...sigForm}>
+                                <form
+                                        className="flex flex-col gap-4"
+                                        onSubmit={sigForm.handleSubmit(() => {})}
+                                >
 					<FormField
 						control={sigForm.control}
 						name="sig"
@@ -142,10 +174,24 @@ export default function Encoder() {
 								<FormMessage />
 							</FormItem>
 						)}
-					/>
-				</form>
-			</Form>
-			{sigError && <div className="text-red-500 text-sm">{sigError}</div>}
+                                        />
+                                </form>
+                        </Form>
+                        {sigError && <div className="text-red-500 text-sm">{sigError}</div>}
+                        {abiItems && abiItems.length > 1 && (
+                                <select
+                                        className="border-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-md bg-transparent px-3 py-2 text-sm"
+                                        value={selectedIndex}
+                                        onChange={(e) => setSelectedIndex(Number(e.target.value))}
+                                >
+                                        {abiItems.map((item, idx) => (
+                                                <option key={idx} value={idx}>
+                                                        {"type" in item ? item.type : "item"}
+                                                        {"name" in item && item.name ? ` ${item.name}` : ""}
+                                                </option>
+                                        ))}
+                                </select>
+                        )}
 			{abiObj && (
 				<Form {...paramForm}>
 					<form

--- a/src/lib/full-abi/fromAbi.test.ts
+++ b/src/lib/full-abi/fromAbi.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { fullAbi } from "./index";
+
+const abi = [
+  {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      { indexed: true, name: "from", type: "address" },
+      { indexed: true, name: "to", type: "address" },
+      { indexed: false, name: "value", type: "uint256" },
+    ],
+    anonymous: false,
+  },
+] as const;
+
+test("select by name", () => {
+  const item = fullAbi.fromAbi(abi, "transfer");
+  expect(item).not.toBeNull();
+  if (item) {
+    expect("type" in item && item.type).toBe("function");
+    // @ts-expect-error
+    expect(item.name).toBe("transfer");
+  }
+});
+
+test("select by selector", () => {
+  const item = fullAbi.fromAbi(abi, "0xa9059cbb");
+  expect(item).not.toBeNull();
+  if (item) {
+    expect("type" in item && item.type).toBe("function");
+    // @ts-expect-error
+    expect(item.name).toBe("transfer");
+  }
+});
+
+test("returns null for unknown", () => {
+  expect(fullAbi.fromAbi(abi, "foo")).toBeNull();
+  expect(fullAbi.fromAbi(abi, "0x00000000")).toBeNull();
+});


### PR DESCRIPTION
## Summary
- add `fromAbi` helper to parse ABI arrays
- document usage in README
- test ABI lookup by name or selector
- use `fullAbi.fromAbi` in decoder and encoder
- show dropdown to select ABI item when multiple ABI entries are supplied

## Testing
- `pnpm test` *(fails: vitest not found)*
- `npx tsc --noEmit` *(fails: cannot find vite/client type)*

------
https://chatgpt.com/codex/tasks/task_e_685fe6854004832b8d84342063c7b625