### PR TITLE
Add constructor decoding support

### DIFF
--- a/src/lib/full-abi/constructor.test.ts
+++ b/src/lib/full-abi/constructor.test.ts
@@ -3,31 +3,29 @@ import { expect, test } from "vitest";
 import { fullAbi } from "./index";
 
 test("constructor", () => {
-        const abi = "constructor(address owner, uint256 amount)" as const;
-        const abiItem = fullAbi.from(abi);
-        const params = fullAbi.getParameter(abiItem);
-        const bytecode = "0x" as const;
-        const encoded = fullAbi.encode(abiItem, [
-                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
-                "123",
-        ], { bytecode }) as `0x${string}`;
-        const decoded = fullAbi.decode(abiItem, {
-                bytecode,
-                data: encoded,
-        });
-        expect(abiItem.type).toBe("constructor");
-        expect(params).toEqual([
-                { name: "owner", type: "address" },
-                { name: "amount", type: "uint256" },
-        ]);
-        expect(encoded).toBe(
-                AbiConstructor.encode(abiItem as AbiConstructor.AbiConstructor, {
-                        bytecode,
-                        args: ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", 123n],
-                }),
-        );
-        expect(decoded).toEqual([
-                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
-                123n,
-        ]);
+	const abi = "constructor(address owner, uint256 amount)" as const;
+	const abiItem = fullAbi.from(abi);
+	const params = fullAbi.getParameter(abiItem);
+	const bytecode = "0x" as const;
+	const encoded = fullAbi.encode(
+		abiItem,
+		["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", "123"],
+		{ bytecode },
+	) as `0x${string}`;
+	const decoded = fullAbi.decode(abiItem, {
+		bytecode,
+		data: encoded,
+	});
+	expect(abiItem.type).toBe("constructor");
+	expect(params).toEqual([
+		{ name: "owner", type: "address" },
+		{ name: "amount", type: "uint256" },
+	]);
+	expect(encoded).toBe(
+		AbiConstructor.encode(abiItem as AbiConstructor.AbiConstructor, {
+			bytecode,
+			args: ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", 123n],
+		}),
+	);
+	expect(decoded).toEqual(["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", 123n]);
 });

--- a/src/lib/full-abi/constructor.test.ts
+++ b/src/lib/full-abi/constructor.test.ts
@@ -1,0 +1,33 @@
+import { AbiConstructor } from "ox";
+import { expect, test } from "vitest";
+import { fullAbi } from "./index";
+
+test("constructor", () => {
+        const abi = "constructor(address owner, uint256 amount)" as const;
+        const abiItem = fullAbi.from(abi);
+        const params = fullAbi.getParameter(abiItem);
+        const bytecode = "0x" as const;
+        const encoded = fullAbi.encode(abiItem, [
+                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+                "123",
+        ], { bytecode }) as `0x${string}`;
+        const decoded = fullAbi.decode(abiItem, {
+                bytecode,
+                data: encoded,
+        });
+        expect(abiItem.type).toBe("constructor");
+        expect(params).toEqual([
+                { name: "owner", type: "address" },
+                { name: "amount", type: "uint256" },
+        ]);
+        expect(encoded).toBe(
+                AbiConstructor.encode(abiItem as AbiConstructor.AbiConstructor, {
+                        bytecode,
+                        args: ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", 123n],
+                }),
+        );
+        expect(decoded).toEqual([
+                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+                123n,
+        ]);
+});

--- a/src/lib/full-abi/fullAbi.ts
+++ b/src/lib/full-abi/fullAbi.ts
@@ -109,7 +109,10 @@ export function getParameter(abiItem: from.ReturnType) {
 
 export function decode(
 	abiItem: from.ReturnType,
-	data: Hex.Hex | { data?: Hex.Hex; topics: readonly Hex.Hex[] },
+	data:
+		| Hex.Hex
+		| { data?: Hex.Hex; topics: readonly Hex.Hex[] }
+		| { bytecode: Hex.Hex; data: Hex.Hex },
 ) {
 	if ("type" in abiItem && abiItem.type === "function") {
 		if (typeof data !== "string") {
@@ -119,7 +122,7 @@ export function decode(
 		return Array.isArray(res) ? res : [res];
 	}
 	if ("type" in abiItem && abiItem.type === "event") {
-		if (typeof data === "string")
+		if (typeof data === "string" || !("topics" in data))
 			throw new Error("Event decoding requires topics and data object");
 		return AbiEvent.decode(abiItem, data);
 	}
@@ -130,19 +133,19 @@ export function decode(
 		const res = AbiError.decode(abiItem, data) ?? [];
 		return Array.isArray(res) ? res : [res];
 	}
-        if ("type" in abiItem && abiItem.type === "constructor") {
-                if (typeof data === "string" || !("bytecode" in data)) {
-                        throw new Error(
-                                "Constructor decoding requires { bytecode, data } object",
-                        );
-                }
-                const res =
-                        AbiConstructor.decode(abiItem, {
-                                bytecode: (data as { bytecode: Hex.Hex }).bytecode,
-                                data: (data as { data: Hex.Hex }).data ?? "0x",
-                        }) ?? [];
-                return Array.isArray(res) ? res : [res];
-        }
+	if ("type" in abiItem && abiItem.type === "constructor") {
+		if (typeof data === "string" || !("bytecode" in data)) {
+			throw new Error(
+				"Constructor decoding requires { bytecode, data } object",
+			);
+		}
+		const res =
+			AbiConstructor.decode(abiItem, {
+				bytecode: (data as { bytecode: Hex.Hex }).bytecode,
+				data: (data as { data: Hex.Hex }).data ?? "0x",
+			}) ?? [];
+		return Array.isArray(res) ? res : [res];
+	}
 	if ("components" in abiItem && abiItem.components.length > 0) {
 		// if (options.packed) {
 		//     const res = AbiParameters.d(abiItem.components, data) ?? [];

--- a/src/lib/full-abi/fullAbi.ts
+++ b/src/lib/full-abi/fullAbi.ts
@@ -130,10 +130,19 @@ export function decode(
 		const res = AbiError.decode(abiItem, data) ?? [];
 		return Array.isArray(res) ? res : [res];
 	}
-	// if ("type" in abiItem && abiItem.type === "constructor") {
-	//     const res = AbiConstructor.decode(abiItem, data) ?? [];
-	//     return Array.isArray(res) ? res : [res];
-	// }
+        if ("type" in abiItem && abiItem.type === "constructor") {
+                if (typeof data === "string" || !("bytecode" in data)) {
+                        throw new Error(
+                                "Constructor decoding requires { bytecode, data } object",
+                        );
+                }
+                const res =
+                        AbiConstructor.decode(abiItem, {
+                                bytecode: (data as { bytecode: Hex.Hex }).bytecode,
+                                data: (data as { data: Hex.Hex }).data ?? "0x",
+                        }) ?? [];
+                return Array.isArray(res) ? res : [res];
+        }
 	if ("components" in abiItem && abiItem.components.length > 0) {
 		// if (options.packed) {
 		//     const res = AbiParameters.d(abiItem.components, data) ?? [];


### PR DESCRIPTION
## Summary
- enable decoding constructors in `fullAbi.decode`
- add unit test for constructor encode/decode

## Testing
- `pnpm test` *(fails: Command "vitest" not found)*
- `pnpm lint` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_686365e8831c832b940e917ace84b3f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify correct encoding and decoding of constructor ABI items, ensuring accurate handling of parameters and data.

* **Bug Fixes**
  * Improved input validation and decoding logic for constructor ABI items, providing stricter checks and more reliable decoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->